### PR TITLE
add icon to open or close the chat configuration

### DIFF
--- a/frontend/components/IconThreeDots.vue
+++ b/frontend/components/IconThreeDots.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts">
+
+</script>
+
+<template>
+  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-three-dots-vertical" viewBox="0 0 16 16">
+    <path d="M9.5 13a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0zm0-5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0zm0-5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z"/>
+  </svg>
+</template>
+
+<style scoped>
+
+</style>

--- a/frontend/components/MessageAreaNavBar.vue
+++ b/frontend/components/MessageAreaNavBar.vue
@@ -34,6 +34,7 @@ function toggleOpenChatConfig() {
       </div>
 
     </div>
+    <icon-three-dots class="self" role="button" @click="() => toggleOpenChatConfig()"/>
 
   </div>
 </template>


### PR DESCRIPTION
A simple icon to open or close the chat configuration, the functionality already exists by clicking on the chat bar but it is not intuitive