### PR TITLE
Accept additional zip content types (application/x-zip-compressed, application/octet-stream) in import controller

### DIFF
--- a/backend/infra/web/src/main/kotlin/dev/marcal/chatvault/web/ChatImportExportController.kt
+++ b/backend/infra/web/src/main/kotlin/dev/marcal/chatvault/web/ChatImportExportController.kt
@@ -80,6 +80,11 @@ class ChatImportExportController(
         return ResponseEntity.noContent().build()
     }
 
+    private val zipMimeTypes = setOf(
+        "application/zip",
+        "application/x-zip-compressed",
+        "application/octet-stream"
+    )
 
     private fun getFileType(file: MultipartFile): FileTypeInputEnum {
         val fileType = when (file.contentType) {
@@ -89,7 +94,8 @@ class ChatImportExportController(
             )
 
             "text/plain" -> FileTypeInputEnum.TEXT
-            "application/zip" -> FileTypeInputEnum.ZIP
+            in zipMimeTypes -> FileTypeInputEnum.ZIP
+
             else -> throw ResponseStatusException(
                 HttpStatus.UNSUPPORTED_MEDIA_TYPE,
                 "This file cannot be imported. Media type not supported ${HtmlUtils.htmlEscape(file.contentType!!)}."
@@ -97,6 +103,8 @@ class ChatImportExportController(
         }
         return fileType
     }
+
+
 
     private fun importChat(
         chatId: Long?,


### PR DESCRIPTION
**Problem**
Import requests were failing with: This file cannot be imported. Media type not supported application/x-zip-compressed.

**Solution**
This PR enhances the content-type validation used during chat file import.
Previously, the backend only accepted application/zip, which caused uploads to fail when using Windows browsers

This update adds support for several commonly used ZIP content-types:

- application/x-zip-compressed (Windows / PowerShell)
- application/octet-stream (fallback used by many browsers and tools)
- Other equivalent ZIP MIME variations
