### PR TITLE
feat: integrate Flyway database migrations

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-webflux")
+    implementation("org.flywaydb:flyway-core:10.22.0")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("io.projectreactor.kotlin:reactor-kotlin-extensions")
     implementation("org.jetbrains.kotlin:kotlin-reflect")

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -8,7 +8,15 @@ spring.datasource.url=jdbc:postgresql://localhost:5432/chatvault
 spring.datasource.username=usr_chatvault
 spring.datasource.password=secret
 spring.datasource.driver-class-name=org.postgresql.Driver
-spring.jpa.hibernate.ddl-auto=update
+spring.jpa.hibernate.ddl-auto=validate
+
+# Flyway Configuration
+spring.flyway.enabled=true
+spring.flyway.locations=classpath:db/migration
+spring.flyway.baselineOnMigrate=true
+spring.flyway.baselineVersion=1
+spring.flyway.validateOnMigrate=true
+spring.flyway.placeholderReplacement=true
 
 chatvault.email.host=<set imap host>
 chatvault.email.port=<set imap port>

--- a/backend/src/main/resources/db/migration/V1__Initial_schema.sql
+++ b/backend/src/main/resources/db/migration/V1__Initial_schema.sql
@@ -1,0 +1,32 @@
+-- Create chat table
+CREATE TABLE IF NOT EXISTS chat (
+    id BIGINT NOT NULL PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+    name VARCHAR(255) NOT NULL,
+    external_id VARCHAR(255),
+    bucket VARCHAR(255) NOT NULL,
+    CONSTRAINT chat_external_id_key UNIQUE (external_id)
+);
+
+-- Create indexes on chat table
+CREATE INDEX IF NOT EXISTS idx_chat_external_id ON chat(external_id);
+CREATE INDEX IF NOT EXISTS idx_chat_name ON chat(name);
+
+-- Create message table
+CREATE TABLE IF NOT EXISTS message (
+    id BIGINT NOT NULL PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+    author VARCHAR(255) NOT NULL,
+    author_type VARCHAR(255) NOT NULL,
+    created_at TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+    content TEXT NOT NULL,
+    attachment_path VARCHAR(255),
+    attachment_name VARCHAR(255),
+    chat_id BIGINT NOT NULL,
+    external_id VARCHAR(255),
+    CONSTRAINT message_external_id_key UNIQUE (external_id),
+    CONSTRAINT fk_message_chat_id FOREIGN KEY (chat_id) REFERENCES chat(id) ON DELETE CASCADE
+);
+
+-- Create indexes on message table
+CREATE INDEX IF NOT EXISTS idx_message_chat_id ON message(chat_id);
+CREATE INDEX IF NOT EXISTS idx_message_external_id ON message(external_id);
+CREATE INDEX IF NOT EXISTS idx_message_created_at ON message(created_at);


### PR DESCRIPTION
Replace Hibernate's auto-update with versioned migrations for better schema control and auditability. This enables reproducible schema deployments across environments.

Changes:
- Add Flyway 10.22.0 (community edition) dependency to Gradle build
- Switch Hibernate from ddl-auto=update to validate mode to prevent untracked schema changes
- Configure Flyway with baselineOnMigrate=true to preserve existing data when migrations take over
- Create initial V1__Initial_schema.sql migration with complete schema definition:
  * chat table with IDENTITY PK, UNIQUE constraint on external_id
  * message table with IDENTITY PK, FK to chat with CASCADE delete
  * Strategic indexes on external_id, name, chat_id, created_at for query performance
- Add Flyway configuration properties for validation and migration tracking

Migration strategy:
- v1: Initial schema baseline matching current Hibernate-managed tables
- Future: Create Vn__description.sql files for incremental schema changes